### PR TITLE
change 'let' to 'var' to pass ES5 for phantomjs

### DIFF
--- a/src/tools/volcano_tool.js
+++ b/src/tools/volcano_tool.js
@@ -317,8 +317,8 @@ phantasus.volcanoTool.prototype = {
     );
     var logfcCutoff = _this.formBuilder.getValue("Absolute_logFC_significance");
 
-    let sigIndex = [];
-    let nonSigIndex = [];
+    var sigIndex = [];
+    var nonSigIndex = [];
     logfcValues.map(Math.abs).forEach(function(a, i) {
       if (a >= logfcCutoff && pvalValues[i] <= pvalCutoff) sigIndex.push(i);
       else nonSigIndex.push(i);


### PR DESCRIPTION
Phantomjs version we are using only supports ES5 features. We should consider upgrading its version
https://github.com/ariya/phantomjs/issues/14506
Changing let to var to pass the tests.
